### PR TITLE
add `var.create_resource_group` so we can reuse existing resource gro…

### DIFF
--- a/examples/named_cluster/variables.tf
+++ b/examples/named_cluster/variables.tf
@@ -1,3 +1,9 @@
+variable "create_resource_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 variable "location" {
   default = "eastus"
 }

--- a/examples/startup/main.tf
+++ b/examples/startup/main.tf
@@ -7,28 +7,35 @@ resource "random_id" "prefix" {
 }
 
 resource "azurerm_resource_group" "main" {
+  count = var.create_resource_group ? 1 : 0
+
   name     = coalesce(var.resource_group_name, "${random_id.prefix.hex}-rg")
   location = var.location
 }
 
+locals {
+  resource_group = {
+    name     = var.create_resource_group ? azurerm_resource_group.main[0].name : var.resource_group_name
+    location = var.location
+  }
+}
+
 data "null_data_source" "resource_group" {
   inputs = {
-    name = azurerm_resource_group.main.name
+    name = local.resource_group.name
   }
-
-  depends_on = [azurerm_resource_group.main]
 }
 
 resource "azurerm_virtual_network" "test" {
   name                = "${random_id.prefix.hex}-vn"
   address_space       = ["10.52.0.0/16"]
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
 }
 
 resource "azurerm_subnet" "test" {
   name                                           = "${random_id.prefix.hex}-sn"
-  resource_group_name                            = azurerm_resource_group.main.name
+  resource_group_name                            = local.resource_group.name
   virtual_network_name                           = azurerm_virtual_network.test.name
   address_prefixes                               = ["10.52.0.0/24"]
   enforce_private_link_endpoint_network_policies = true

--- a/examples/startup/variables.tf
+++ b/examples/startup/variables.tf
@@ -5,6 +5,12 @@ variable "location" {
 variable "client_id" {}
 variable "client_secret" {}
 
+variable "create_resource_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 variable "resource_group_name" {
   type    = string
   default = null

--- a/examples/without_monitor/main.tf
+++ b/examples/without_monitor/main.tf
@@ -7,28 +7,35 @@ resource "random_id" "prefix" {
 }
 
 resource "azurerm_resource_group" "main" {
+  count = var.create_resource_group ? 1 : 0
+
   name     = coalesce(var.resource_group_name, "${random_id.prefix.hex}-rg")
   location = var.location
 }
 
+locals {
+  resource_group = {
+    name     = var.create_resource_group ? azurerm_resource_group.main[0].name : var.resource_group_name
+    location = var.location
+  }
+}
+
 data "null_data_source" "resource_group" {
   inputs = {
-    name = azurerm_resource_group.main.name
+    name = local.resource_group.name
   }
-
-  depends_on = [azurerm_resource_group.main]
 }
 
 resource "azurerm_virtual_network" "test" {
   name                = "${random_id.prefix.hex}-vn"
   address_space       = ["10.52.0.0/16"]
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  location            = local.resource_group.location
+  resource_group_name = local.resource_group.name
 }
 
 resource "azurerm_subnet" "test" {
   name                                           = "${random_id.prefix.hex}-sn"
-  resource_group_name                            = azurerm_resource_group.main.name
+  resource_group_name                            = local.resource_group.name
   virtual_network_name                           = azurerm_virtual_network.test.name
   address_prefixes                               = ["10.52.0.0/24"]
   enforce_private_link_endpoint_network_policies = true

--- a/examples/without_monitor/variables.tf
+++ b/examples/without_monitor/variables.tf
@@ -1,3 +1,9 @@
+variable "create_resource_group" {
+  type     = bool
+  default  = true
+  nullable = false
+}
+
 variable "location" {
   default = "eastus"
 }


### PR DESCRIPTION
…up in acc test in ci pipeline.

<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


