### PR TITLE
Exit and first validation error. Provide context to debug

### DIFF
--- a/scripts/terraform-validate.sh
+++ b/scripts/terraform-validate.sh
@@ -6,12 +6,13 @@ echo "==> Checking examples terraform codes are validate..."
 examples=$(find ./examples -maxdepth 1 -mindepth 1 -type d)
 for d in $examples; do
   (echo "===> Terraform validating in " $d && cd $d && rm -f .terraform.lock.hcl && terraform init -upgrade && terraform validate -json | jq -e .valid) || error=true
+  if ${error}; then
+     echo "------------------------------------------------"
+     echo ""
+     echo "Some Terraform codes contain errors."
+     echo "$(cd $d && terraform validate -json)"
+     echo ""
+     exit 1
+  fi
 done
-if ${error}; then
-  echo "------------------------------------------------"
-  echo ""
-  echo "Some Terraform codes contain errors."
-  echo ""
-  exit 1
-fi
 exit 0


### PR DESCRIPTION
This PR changes the `terraform-validate.sh` script to exit at the first error, and to print to screen the `json` output that is invalid, so that looking at the CI output is possible to understand what is the problem to fix.

With the earlier version the CI output did not have any information of about the why of the CI failure.

Also because the tests take a long time to run, it would be best to abort at the first error.

